### PR TITLE
Negative immediate representation in binary opcode table is fixed

### DIFF
--- a/datapath-gui/src/main/java/elw/dp/app/InstructionsTableModel.java
+++ b/datapath-gui/src/main/java/elw/dp/app/InstructionsTableModel.java
@@ -9,7 +9,7 @@ import javax.swing.table.AbstractTableModel;
 
 public class InstructionsTableModel extends AbstractTableModel {
     public static final String COL_ADDR = "Addr";
-    private static final String COL_BIN = "Hex";
+    private static final String COL_BIN = "Bin";
     private static final String COL_LABELS = "Labels";
     public static final String COL_CODE = "Code";
     public static final String COL_ACC = "rw";

--- a/datapath/src/main/java/elw/dp/mips/Instruction.java
+++ b/datapath/src/main/java/elw/dp/mips/Instruction.java
@@ -75,7 +75,7 @@ public class Instruction {
             final String mask = tokenToMask.get(token);
             final int maskStart = res.indexOf(mask);
             if (maskStart >= 0) {
-                res.replace(maskStart, maskStart + mask.length(), Data.str(getBits(token), 2, getWidth(token)));
+                res.replace(maskStart, maskStart + mask.length(), Data.strTwosComplement(getBits(token), getWidth(token)));
             }
         }
 

--- a/datapath/src/main/java/elw/dp/mips/asm/Data.java
+++ b/datapath/src/main/java/elw/dp/mips/asm/Data.java
@@ -195,6 +195,16 @@ public class Data {
 
         return str.toString();
     }
+    
+    public static String strTwosComplement(final long val, final int digits) {
+        final StringBuffer str = new StringBuffer(Long.toBinaryString(val));
+        final char paddingChar = val < 0 ? '1' : '0';
+        while (str.length() < digits) {
+            str.insert(0, paddingChar);
+        }
+
+        return str.substring(str.length() - digits);
+    }
 
     public static long comp(long val, int digits) {
         return val < 0 ? (2 << digits) - val : val;


### PR DESCRIPTION
Minor change was to rename a column from "Hex" to "Bin", because that's what was there in the column.
Fixing negative immediates might have required changing Data.str(), but I chose to write a separate method for the task to save intended behavior of the method mentioned.
Let me know what you think.
